### PR TITLE
make sure aside-container is display block

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -39,6 +39,10 @@
   color: #222222;
 }
 
+.aside-container {
+  display: block;
+}
+
 @media all and (max-width: 1000px) {
   .idyll-root {
     max-width: none;


### PR DESCRIPTION
Quick style fix for the aside. 

@fredhohman we should apply this to the site-wide CSS, it seems like the difference from the asides in previous issues is that we were wrapping those in `[Desktop]` and `[Mobile]` tags, but it should work without those. 